### PR TITLE
Update libretro.c

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -528,17 +528,21 @@ static int geo_savedata_load_vfs(unsigned datatype, const char *filename) {
 
     switch (datatype) {
         case GEO_SAVEDATA_NVRAM: {
-            if (geo_get_system() == SYSTEM_AES)
+            if (geo_get_system() == SYSTEM_AES || ngsys.cdmode)
                 return 2;
             dataptr = geo_mem_ptr(GEO_MEMTYPE_NVRAM, &datasize);
             break;
         }
         case GEO_SAVEDATA_CARTRAM: {
-            dataptr = geo_mem_ptr(GEO_MEMTYPE_CARTRAM, &datasize);
+            if (!ngsys.sram_present || ngsys.cdmode)
+                return 2;
+           dataptr = geo_mem_ptr(GEO_MEMTYPE_CARTRAM, &datasize);
             break;
         }
         case GEO_SAVEDATA_MEMCARD: {
-            dataptr = geo_mem_ptr(GEO_MEMTYPE_MEMCARD, &datasize);
+            if (ngsys.cdmode)
+                return 2;
+           dataptr = geo_mem_ptr(GEO_MEMTYPE_MEMCARD, &datasize);
             break;
         }
         default: return 2;

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -536,13 +536,13 @@ static int geo_savedata_load_vfs(unsigned datatype, const char *filename) {
         case GEO_SAVEDATA_CARTRAM: {
             if (!ngsys.sram_present || ngsys.cdmode)
                 return 2;
-           dataptr = geo_mem_ptr(GEO_MEMTYPE_CARTRAM, &datasize);
+            dataptr = geo_mem_ptr(GEO_MEMTYPE_CARTRAM, &datasize);
             break;
         }
         case GEO_SAVEDATA_MEMCARD: {
             if (ngsys.cdmode)
                 return 2;
-           dataptr = geo_mem_ptr(GEO_MEMTYPE_MEMCARD, &datasize);
+            dataptr = geo_mem_ptr(GEO_MEMTYPE_MEMCARD, &datasize);
             break;
         }
         default: return 2;


### PR DESCRIPTION
When we launch Neo-Geo CD games, geolith create 3 save files (GameName.nv, GameName.mcr, GameName.srm). But only srm files are used for NGCD games.

This request is a copy paste of src from geo.c file. nothing original.
After, nv files and mcr files will not be writen with NGCD games.
No change for Neo-Geo games.