### PR TITLE
libretro: Initialize log_cb with no-op fallback to prevent NULL deref

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -109,7 +109,10 @@ static int32_t trackball_y = 0;
 static uint32_t dbflags = 0;
 
 // libretro callbacks
-static retro_log_printf_t log_cb = NULL;
+static void fallback_log(enum retro_log_level level, const char *fmt, ...) {
+    (void)level; (void)fmt;
+}
+static retro_log_printf_t log_cb = fallback_log;
 static retro_video_refresh_t video_cb = NULL;
 static retro_audio_sample_t audio_cb = NULL;
 static retro_audio_sample_batch_t audio_batch_cb = NULL;


### PR DESCRIPTION
## Problem

On at least the current libretro Android nightly build (`geolith_libretro_android.so`, dated 2026-04-16, arm64-v8a), `log_cb` is never assigned during `retro_init`. The first `log_cb(...)` call from `retro_load_game` then dereferences NULL and SIGSEGVs.

## Reproduction

I'm running the Android buildbot `.so` from a custom Avalonia/.NET frontend with a small C bridge that handles the env callbacks. After loading a NeoGeo cart (`*.neo`), my bridge logs every `environ_cb` invocation. The full sequence from the buildbot binary is:

```
#1  cmd 52  PERFORMANCE_LEVEL
#2  cmd 16  SET_VARIABLES
#3  cmd 69
#4  cmd 27  GET_CORE_OPTIONS_VERSION   (frontend returns false → V0 path)
#5  cmd 51  GET_INPUT_BITMASKS
#6  cmd 45  GET_VFS_INTERFACE
#7-26 cmd 15 GET_VARIABLE × ~20 (geolith options)
```

`retro_init` in `libretro.c` calls `GET_LOG_INTERFACE` (cmd 40) **before** `GET_INPUT_BITMASKS`, but cmd 40 is missing entirely from the binary's runtime calls. My env counter is sequential 1→26 with no gap, and my handler for cmd 40 (verified working with other cores) never fires. Most likely an LTO/codegen artifact from `-O2 -flto` on the Android NDK build — the call appears to have been elided or reordered out.

## Crash site

PC `0x3bef4` inside the .so, called from `bridge_load_game → retro_load_game`. The crash is right after `GET_SAVE_DIRECTORY` succeeds — `retro_load_game` enters the savedata-load loop (`libretro.c:1360-1370`) and on the first iteration calls:

```c
log_cb(RETRO_LOG_DEBUG, "Load Failed: %s\n", savename);
```

…for a savefile that doesn't exist yet on a fresh install. `log_cb` is NULL → SIGSEGV.

## Fix

Default `log_cb` to a no-op fallback at file scope so it's always safe to call, regardless of whether the frontend wires up the log interface or whether the optimizer keeps the `GET_LOG_INTERFACE` call in `retro_init`:

```c
static void fallback_log(enum retro_log_level level, const char *fmt, ...) {
    (void)level; (void)fmt;
}
static retro_log_printf_t log_cb = fallback_log;
```

This is the same pattern most other libretro cores use defensively. With this patch applied and rebuilt for arm64-v8a (NDK r27, same Application.mk), Geolith boots and runs NeoGeo carts correctly on Android.

## Notes for review

- I did **not** dig into why the NDK build apparently elides the `GET_LOG_INTERFACE` call. This patch defends against that case rather than chasing it. If the elision is a real toolchain issue worth investigating separately, happy to file a second issue with my full env-callback log.
- No behavioral change for frontends that *do* call `GET_LOG_INTERFACE` — `log_cb` gets reassigned to the real logger as before.